### PR TITLE
example.html: Fix selectPackaging call in packaging-select widget

### DIFF
--- a/example.html
+++ b/example.html
@@ -29,7 +29,7 @@
 							<td>
 								<select ng-options="prod.packaged.code as productPackagingLabel(prod) for prod in product.packaging"
 								        ng-model="product.code"
-								        ng-change="product.selectPackaging(packaged_product.code)" />
+								        ng-change="product.selectPackaging(product.code)" />
 							</td>
 							<td>
 								<ul ng-if="product.packaged.categories().length">


### PR DESCRIPTION
packaged_product wasn't defined, so change's weren't doing anything
useful in selectPackaging.  The fixed version works like this:

1. User selects an option in the drop-down
2. Angular sets product.code (because it's ng-model)
3. Angular triggers ng-change
4. selectPackaging fires with the new code

I'd broken this in ac2181f8 (azure-providers.js: Add PackagedProduct
and update associated APIs, 2015-02-23).  That was a big change, and I
broke a few of other things too, grep the logs for ac2181f ;).