### PR TITLE
Convert lower_case to camelCase to match JavaScript style

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ AzureCategory
 Use the `AzureCategory` factory to show a category's position in the
 hierarchy.  Calling:
 
-    AzureCategory(category_id)
+    AzureCategory(categoryId)
 
 will return an `Category` instance with the following properties:
 

--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ AzureOrders
 
 Use the `AzureOrders` factory to create an `Orders` instance. Calling:
 
-    AzureOrders(person_id)
+    AzureOrders(personId)
 
 will return a reference to that person's `Orders` instance
 with the following properties:
@@ -294,7 +294,7 @@ AzureCarts
 
 Use the `AzureCarts` factory to manage a customer's carts.  Calling:
 
-    AzureCarts(person_id)
+    AzureCarts(personId)
 
 will return a reference to that person's singleton `Carts` instance
 with the following properties:

--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ with the following properties:
 The `Cart` instance subclasses `AzureOrder` and has the additional
 property:
 
-* `addLine(product_code, quantity_ordered)`, a method to add an
+* `addLine(productCode, quantity_ordered)`, a method to add an
   order-line to the order and update the associated state.
 
 The `OrderLine` instances subclass `AzureOrderLine` and have the

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ will return an `Product` instance with the following properties:
 * `code`, the code for the currently selected packaged product, which
   is mostly useful as a value for [ng-model on select widgets][select]
   and the like to avoid accidentally editing `packaged.code`.
-* `selectPackaging(packaged_product_code)`, a method for changing the
+* `selectPackaging(packagedProductCode)`, a method for changing the
   currently selected packaged product (selection will not persist
   beyond page refreshes).  Calling with a falsy argument will select
   the product's cheapest packaging.

--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ with the following properties:
   progress.
 * `cart`, the currently selected `Cart` (which is also in the `carts`
   array).
-* `selectCart(order_id)`, a method for changing the current default
+* `selectCart(orderId)`, a method for changing the current default
   cart (selection will not persist beyond page refreshes).
 * `createCart(order[, select])`, a method for creating a new cart.
   The `order` argument can be either an `AzureAPI.order` $resource or

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ AzureProduct
 Use the `AzureProduct` factory to manage a product with different
 packaging (e.g. “2.7 ozs.” and “12 x 2.7 ozs.”).  Calling:
 
-    AzureProduct(product_id)
+    AzureProduct(productId)
 
 will return an `Product` instance with the following properties:
 

--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ with the following properties:
 The `Cart` instance subclasses `AzureOrder` and has the additional
 property:
 
-* `addLine(productCode, quantity_ordered)`, a method to add an
+* `addLine(productCode, quantityOrdered)`, a method to add an
   order-line to the order and update the associated state.
 
 The `OrderLine` instances subclass `AzureOrderLine` and have the

--- a/README.md
+++ b/README.md
@@ -97,11 +97,11 @@ matching items, it returns a $resource whose `count` property is the
 number of possible items matching your query (how many you'd get in a
 `query` that didn't set `limit`).  Use it with controller code like:
 
-    $scope.favorites_count = AzureAPI.product.count({person: person.id});
+    $scope.favoritesCount = AzureAPI.product.count({person: person.id});
 
 and template code like:
 
-    You have {{favorites_count.count}} favorites.
+    You have {{favoritesCount.count}} favorites.
 
 Other methods
 -------------

--- a/azure-providers.js
+++ b/azure-providers.js
@@ -467,7 +467,7 @@ var azureProvidersModule = angular
     }])
     .factory('AzureProduct', ['$q', 'AzureAPI', 'AzureCategory', 'AzureObjectPromiseCache', function AzureProductFactory($q, AzureAPI, AzureCategory, AzureObjectPromiseCache) {
         var cache = new AzureObjectPromiseCache('product');
-        var packaged_cache = {};
+        var packagedCache = {};
 
         var PackagedProduct = function(packaged_product) {
             this.packaged = packaged_product;
@@ -545,7 +545,7 @@ var azureProvidersModule = angular
             var code = null;
             if (product.hasOwnProperty('code')) {
                 code = product.code;
-                promise = packaged_cache[code];
+                promise = packagedCache[code];
                 if (!promise) {
                     if (queryParameters === undefined) {
                         queryParameters = {};
@@ -562,7 +562,7 @@ var azureProvidersModule = angular
                         }
                         return cache.getObjectPromise(products[0].id);
                     });
-                    packaged_cache[code] = promise;
+                    packagedCache[code] = promise;
                 }
             } else if (product.hasOwnProperty('id')) {
                 id = product.id;

--- a/azure-providers.js
+++ b/azure-providers.js
@@ -301,10 +301,10 @@ var azureProvidersModule = angular
         }
 
         var _categoryByPathCheck = function(
-                category, _slug, slugs, parent, deferred, path_string) {
+                category, _slug, slugs, parent, deferred, pathString) {
             if (slug(category.name) === _slug) {
                 if (slugs.length) {
-                    _categoryByPath(slugs, category.id, deferred, path_string);
+                    _categoryByPath(slugs, category.id, deferred, pathString);
                 } else {
                     deferred.resolve(new Category(category.id));
                 }
@@ -312,10 +312,10 @@ var azureProvidersModule = angular
             }
         };
 
-        var _categoryByPath = function(slugs, parent, deferred, path_string) {
+        var _categoryByPath = function(slugs, parent, deferred, pathString) {
             var slug = slugs.shift();
             if (!slug) {
-                deferred.reject('empty slug from path ' + path_string);
+                deferred.reject('empty slug from path ' + pathString);
                 return;
             }
             for (var key in cache.objects) {
@@ -324,7 +324,7 @@ var azureProvidersModule = angular
                     continue;
                 }
                 var match = _categoryByPathCheck(
-                    category, slug, slugs, parent, deferred, path_string);
+                    category, slug, slugs, parent, deferred, pathString);
                 if (match) {
                     return;
                 }
@@ -341,11 +341,11 @@ var azureProvidersModule = angular
                 });
                 var match = categories.some(function(category) {
                     return _categoryByPathCheck(
-                        category, slug, slugs, parent, deferred, path_string);
+                        category, slug, slugs, parent, deferred, pathString);
                 });
                 if (!match) {
                     deferred.reject('no match found for slug ' + slug +
-                                    ' from path ' + path_string);
+                                    ' from path ' + pathString);
                     return;
                 }
             });

--- a/azure-providers.js
+++ b/azure-providers.js
@@ -282,11 +282,11 @@ var azureProvidersModule = angular
         var cache = new AzureObjectPromiseCache('category');
         var children = {};
 
-        var get_parent = function(category, ancestor) {
+        var getParent = function(category, ancestor) {
             if (ancestor.parent !== null) {
                 cache.getObjectPromise(ancestor.parent).then(function(cat) {
                     category.ancestors.push(cat);
-                    get_parent(category, cat);
+                    getParent(category, cat);
                     return cat;
                 });
             }
@@ -374,7 +374,7 @@ var azureProvidersModule = angular
                     function(category) {
                         _this.category = category;
                         _this.ancestors = [category];
-                        get_parent(_this, category);
+                        getParent(_this, category);
                         return category;
                     }
                 );

--- a/azure-providers.js
+++ b/azure-providers.js
@@ -251,14 +251,14 @@ var azureProvidersModule = angular
 
         ObjectPromiseCache.prototype.getObjectPromise = function(id) {
             var objectsEntry = this.objects[id];
-            var promises_entry = this.promises[id];
+            var promisesEntry = this.promises[id];
             if (objectsEntry) {
                 var deferred = $q.defer();
                 var promise = deferred.promise;
                 deferred.resolve(objectsEntry);
                 return promise;
-            } else if (promises_entry) {
-                return promises_entry;
+            } else if (promisesEntry) {
+                return promisesEntry;
             } else {
                 var _this = this;
                 var parameters = {};

--- a/azure-providers.js
+++ b/azure-providers.js
@@ -812,12 +812,12 @@ var azureProvidersModule = angular
             return resource.$promise;
         };
 
-        var Carts = function(person_id) {
+        var Carts = function(personId) {
             var _this = this;
             this.carts = [];
             this.cart = null;
             var orders = AzureAPI.order.query({
-                person: person_id,
+                person: personId,
                 status: 'cart',
                 limit: 250,
             });
@@ -899,11 +899,11 @@ var azureProvidersModule = angular
                 'no match found for ' + JSON.stringify(parameters));
         };
 
-        return function(person_id) {
-            if (!cart_sets.hasOwnProperty(person_id)) {
+        return function(personId) {
+            if (!cart_sets.hasOwnProperty(personId)) {
                 /* we don't have an existing instance */
-                cart_sets[person_id] = new Carts(person_id);
+                cart_sets[personId] = new Carts(personId);
             }
-            return cart_sets[person_id];
+            return cart_sets[personId];
         };
     }]);

--- a/azure-providers.js
+++ b/azure-providers.js
@@ -831,16 +831,16 @@ var azureProvidersModule = angular
             });
         };
 
-        Carts.prototype.selectCart = function(order_id) {
+        Carts.prototype.selectCart = function(orderId) {
             var _this = this;
             var match = this.carts.some(function(cart) {
-                if (cart.order.id === order_id) {
+                if (cart.order.id === orderId) {
                     _this.cart = cart;
                     return true;
                 }
             });
             if (!match) {
-                console.log('no match found for ' + order_id + ' in', this.carts);
+                console.log('no match found for ' + orderId + ' in', this.carts);
             }
         };
 

--- a/azure-providers.js
+++ b/azure-providers.js
@@ -43,7 +43,7 @@ var azureProvidersModule = angular
         var _headers = {
             'Accept': 'application/json',
         };
-        var _payload_headers = {
+        var _payloadHeaders = {
             'Content-Type': 'application/json; charset=UTF-8',
         };
         var url = 'https://api.azurestandard.com';
@@ -127,12 +127,12 @@ var azureProvidersModule = angular
                     );
                 }
             };
-            var payload_headers = {};
+            var payloadHeaders = {};
             for (var header in _headers) {
-                payload_headers[header] = _headers[header];
+                payloadHeaders[header] = _headers[header];
             }
-            for (var header in _payload_headers) {
-                payload_headers[header] = _payload_headers[header];
+            for (var header in _payloadHeaders) {
+                payloadHeaders[header] = _payloadHeaders[header];
             }
             _models.forEach(function(model) {
                 var plural = _plurals[model] || model + 's';
@@ -167,7 +167,7 @@ var azureProvidersModule = angular
                         method: 'POST',
                         url: url + '/' + plural,
                         withCredentials: true,
-                        headers: payload_headers,
+                        headers: payloadHeaders,
                     },
                     get: {
                         method: 'GET',
@@ -177,7 +177,7 @@ var azureProvidersModule = angular
                     save: {
                         method: 'PUT',
                         withCredentials: true,
-                        headers: payload_headers,
+                        headers: payloadHeaders,
                     },
                     'delete': {
                         method: 'DELETE',
@@ -190,13 +190,13 @@ var azureProvidersModule = angular
                         method: 'POST',
                         url: url + '/mail/' + model + '/:' + identifier,
                         withCredentials: true,
-                        headers: payload_headers,
+                        headers: payloadHeaders,
                     };
                     actions.mails = {
                         method: 'POST',
                         url: url + '/mail/' + plural,
                         withCredentials: true,
-                        headers: payload_headers,
+                        headers: payloadHeaders,
                     };
                 }
                 if (model === 'packaged-product') {

--- a/azure-providers.js
+++ b/azure-providers.js
@@ -713,7 +713,7 @@ var azureProvidersModule = angular
         };
     }])
     .factory('AzureCarts', ['AzureAPI', 'AzureOrder', 'AzureOrderLine', function AzureCartsFactory(AzureAPI, AzureOrder, AzureOrderLine) {
-        var cart_sets = {};
+        var cartSets = {};
 
         var OrderLine = function(orderLine, cart) {
             AzureOrderLine.call(this, orderLine);
@@ -900,10 +900,10 @@ var azureProvidersModule = angular
         };
 
         return function(personId) {
-            if (!cart_sets.hasOwnProperty(personId)) {
+            if (!cartSets.hasOwnProperty(personId)) {
                 /* we don't have an existing instance */
-                cart_sets[personId] = new Carts(personId);
+                cartSets[personId] = new Carts(personId);
             }
-            return cart_sets[personId];
+            return cartSets[personId];
         };
     }]);

--- a/azure-providers.js
+++ b/azure-providers.js
@@ -469,8 +469,8 @@ var azureProvidersModule = angular
         var cache = new AzureObjectPromiseCache('product');
         var packagedCache = {};
 
-        var PackagedProduct = function(packaged_product) {
-            this.packaged = packaged_product;
+        var PackagedProduct = function(packagedProduct) {
+            this.packaged = packagedProduct;
             this._categories = null;
         };
 
@@ -500,8 +500,8 @@ var azureProvidersModule = angular
                 _this.product = product;
                 _this.packaging = [];
                 var promises = [];
-                _this.product.packaging.forEach(function(packaged_product) {
-                    var packaged = new PackagedProduct(packaged_product);
+                _this.product.packaging.forEach(function(packagedProduct) {
+                    var packaged = new PackagedProduct(packagedProduct);
                     _this.packaging.push(packaged);
                     promises.push(packaged.$promise);
                 });
@@ -519,17 +519,17 @@ var azureProvidersModule = angular
 
         Product.prototype.selectPackaging = function(code) {
             var _this = this;
-            var match = this.packaging.some(function(packaged_product) {
+            var match = this.packaging.some(function(packagedProduct) {
                 if (code) {
-                    if (packaged_product.packaged.code === code) {
-                        _this.packaged = packaged_product;
+                    if (packagedProduct.packaged.code === code) {
+                        _this.packaged = packagedProduct;
                         _this.code = code;
                         return true;
                     }
-                } else if (packaged_product.packaged.tags.indexOf(
+                } else if (packagedProduct.packaged.tags.indexOf(
                         'bargain-bin') == -1) {
-                    _this.packaged = packaged_product;
-                    _this.code = packaged_product.packaged.code;
+                    _this.packaged = packagedProduct;
+                    _this.code = packagedProduct.packaged.code;
                     return true;
                 }
             });

--- a/azure-providers.js
+++ b/azure-providers.js
@@ -250,12 +250,12 @@ var azureProvidersModule = angular
         };
 
         ObjectPromiseCache.prototype.getObjectPromise = function(id) {
-            var objects_entry = this.objects[id];
+            var objectsEntry = this.objects[id];
             var promises_entry = this.promises[id];
-            if (objects_entry) {
+            if (objectsEntry) {
                 var deferred = $q.defer();
                 var promise = deferred.promise;
-                deferred.resolve(objects_entry);
+                deferred.resolve(objectsEntry);
                 return promise;
             } else if (promises_entry) {
                 return promises_entry;

--- a/example.html
+++ b/example.html
@@ -252,9 +252,9 @@
 							AzureAPI['packaged-product'].query({
 								person: person.id,
 								limit: 3,
-							}).$promise.then(function(packaged_products) {
-								packaged_products.forEach(function(packaged_product) {
-									$scope.favorites.push(new AzureProduct(packaged_product));
+							}).$promise.then(function(packagedProducts) {
+								packagedProducts.forEach(function(packagedProduct) {
+									$scope.favorites.push(new AzureProduct(packagedProduct));
 								});
 							});
 						};
@@ -278,10 +278,10 @@
 								$scope.carts = new AzureCarts();
 							} */
 						});
-						$scope.productPackagingLabel = function(packaged_product) {
-							return packaged_product.packaged.code + ' (' +
-								packaged_product.packaged.size + ', $' +
-								packaged_product.packaged.price.dollars + ')';
+						$scope.productPackagingLabel = function(packagedProduct) {
+							return packagedProduct.packaged.code + ' (' +
+								packagedProduct.packaged.size + ', $' +
+								packagedProduct.packaged.price.dollars + ')';
 						};
 					}])
 				.controller(

--- a/example.html
+++ b/example.html
@@ -29,7 +29,7 @@
 							<td>
 								<select ng-options="prod.packaged.code as productPackagingLabel(prod) for prod in product.packaging"
 								        ng-model="product.code"
-								        ng-change="product.selectPackaging(packaged_product.code)" />
+								        ng-change="product.selectPackaging(product.code)" />
 							</td>
 							<td>
 								<ul ng-if="product.packaged.categories().length">

--- a/example.html
+++ b/example.html
@@ -12,7 +12,7 @@
 			<button ng-click="logout()">Logout</button>
 			<div ng-if="favorites.length">
 				<p>
-					You have {{favorites_count.count}} favorites. The first
+					You have {{favoritesCount.count}} favorites. The first
 					{{favorites.length}} are:
 				</p>
 				<table>
@@ -245,7 +245,7 @@
 							$scope.session = AzureAPI.session.get();
 							$scope.orders = new AzureOrders(person.id);
 							$scope.carts = new AzureCarts(person.id);
-							$scope.favorites_count = AzureAPI.product.count({
+							$scope.favoritesCount = AzureAPI.product.count({
 								person: person.id,
 							});
 							$scope.favorites = [];
@@ -264,7 +264,7 @@
 							$scope.session = null;
 							$scope.carts = null;
 							$scope.orders = null;
-							$scope.favorites_count = null;
+							$scope.favoritesCount = null;
 							$scope.favorites = null;
 						};
 						$scope.session = AzureAPI.session.get();


### PR DESCRIPTION
Too much Python predisposes me to write [`lower_case_with_underscores`][1], I'd used it a number of times in this repository.  However, the JavaScript community seems to prefer [camelCase][2].  This PR updates everything turned up by:

    $ git grep '[a-zA-Z0-9]_'

so I'm pretty sure I've caught all occurrences.  There are quite a few commits, because almost every commit is single call to `sed`, which should make the changes easier to review if you want to look through them on a per-commit basis.

This is based on #8 (which removes an existing `packaged_product` that was broken, this PR is just about style), so I wouldn't bother reviewing this until #8 has landed.

[1]: https://www.python.org/dev/peps/pep-0008/#descriptive-naming-styles
[2]: http://jscs.info/rule/requireCamelCaseOrUpperCaseIdentifiers