### PR TITLE
azure-providers.js: Drop 'person' parameter from AzureAPI.drop.get call

### DIFF
--- a/azure-providers.js
+++ b/azure-providers.js
@@ -618,7 +618,6 @@ var azureProvidersModule = angular
         Order.prototype._drop = function() {
             this.drop = AzureAPI.drop.get({
                 id: this.order.drop,
-                person: this.order.customer
             });
         };
 


### PR DESCRIPTION
This looks like a copy/paste error from c4eb73c1 (AzureOrders,
AzureOrder and AzureOrderLine Factories, 2015-07-30), which removed:

  if (order.drop) {
      this.drop = AzureAPI.drop.get({
          id: order.drop,
      });
  }

and added:

  Order.prototype._drop = function() {
      this.drop = AzureAPI.drop.get({
          id: this.order.drop,
          person: this.order.customer
      });
  };

The drop ID should be all we need to get a drop ;).