### PR TITLE
Update 'person' -> 'filter-person'

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ example:
       product.description = 'Delicious!';
       product.$save();
     });
-    var favorites = AzureAPI.product.query({person: you.id});
+    var favorites = AzureAPI.product.query({'filter-person': you.id});
     var order = AzureAPI.order.create({
       customer: you,
       status: 'cart',
@@ -97,7 +97,9 @@ matching items, it returns a $resource whose `count` property is the
 number of possible items matching your query (how many you'd get in a
 `query` that didn't set `limit`).  Use it with controller code like:
 
-    $scope.favoritesCount = AzureAPI.product.count({person: person.id});
+    $scope.favoritesCount = AzureAPI.product.count({
+      'filter-person': person.id
+    });
 
 and template code like:
 

--- a/azure-providers.js
+++ b/azure-providers.js
@@ -692,8 +692,8 @@ var azureProvidersModule = angular
             var _this = this;
             this.orders = [];
             var orders = AzureAPI.order.query({
-                person: personId,
-                limit: 250,
+                'filter-person': personId,
+                'limit': 250,
             });
             orders.$promise.then(function(orders) {
                 orders.forEach(function(order) {
@@ -816,9 +816,9 @@ var azureProvidersModule = angular
             this.carts = [];
             this.cart = null;
             var orders = AzureAPI.order.query({
-                person: personId,
-                status: 'cart',
-                limit: 250,
+                'filter-person': personId,
+                'status': 'cart',
+                'limit': 250,
             });
             orders.$promise.then(function(orders) {
                 orders.forEach(function(order) {

--- a/example.html
+++ b/example.html
@@ -246,12 +246,12 @@
 							$scope.orders = new AzureOrders(person.id);
 							$scope.carts = new AzureCarts(person.id);
 							$scope.favoritesCount = AzureAPI.product.count({
-								person: person.id,
+								'filter-person': person.id,
 							});
 							$scope.favorites = [];
 							AzureAPI['packaged-product'].query({
-								person: person.id,
-								limit: 3,
+								'filter-person': person.id,
+								'limit': 3,
 							}).$promise.then(function(packagedProducts) {
 								packagedProducts.forEach(function(packagedProduct) {
 									$scope.favorites.push(new AzureProduct(packagedProduct));


### PR DESCRIPTION
Catch up with azurestandard/api-spec@2ab80437 (public.json: Add
packagedProduct.favorite boolean and annotate-person parameter,
2015-06-08) which just landed in our implementation
(azurestandard/beehive@550d56e, Merge pull request #1211 from
azurestandard/tk/api-filter-person, 2015-09-24).

After this commit:

    $ git grep person.*: | grep -v filter-person

only returns matches for 'AzureAPI.person', the "'person': 'people'"
entry in _plurals, and the "person: person" entry in the
AzureAPI.register implementation (which is POSTing data, and not
asking for filtered search results).