### PR TITLE
azure-providers.js: Fix product -> orderLine['packaged-product'] reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,8 +290,8 @@ will return an `OrderLine` instance with the following properties:
 * `orderLine`, the order-line object as returned by
   `AzureAPI['order-line'].get(…)`.
 * `product`, the `Product` instance associated with the line
-  (`product` is just the product's code).  See `AzureProduct` for
-  details on this class.
+  (`orderLine['packaged-product']` is just the product's code).  See
+  `AzureProduct` for details on this class.
 
 AzureOrder
 ==========


### PR DESCRIPTION
This parenthetical is trying to explain why we need an AzureProduct
reference here, when we already have an existing product-like field.
It was just using the wrong name for the product-like field.

The old language landed in 115dd62c (README.md: Document the
AzureCarts interface, 2015-01-07) describing
Cart.Orderlines[].productObject.  But since 7f5299c1
(azure-providers.js: Add an OrderLine class wrapping order-line
resources, 2015-02-05) added an OrderLine class (instead of stuffing
information into the API object) the 'product' reference has been
outdated.