### PR TITLE
Adjust to the new API pricing model

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,6 @@ will return an `OrderLine` instance with the following properties:
 
 * `orderLine`, the order-line object as returned by
   `AzureAPI['order-line'].get(…)`.
-* `price`, the total current price for the line in dollars.
 * `product`, the `Product` instance associated with the line
   (`product` is just the product's code).  See `AzureProduct` for
   details on this class.

--- a/azure-providers.js
+++ b/azure-providers.js
@@ -633,19 +633,7 @@ var azureProvidersModule = angular
     .factory('AzureOrderLine', ['AzureProduct', function AzureOrderLineFactory(AzureProduct) {
         var OrderLine = function (orderLine) {
             this.orderLine = orderLine;
-            this._calculatePrice();
             this.product = AzureProduct({code: orderLine['packaged-product']});
-        };
-
-        OrderLine.prototype._calculatePrice = function() {
-            if (this.orderLine.price['per-pound']) {
-                this.price =
-                    this.orderLine.price.dollars * this.orderLine.weight;
-            } else {
-                this.price =
-                    this.orderLine.price.dollars *
-                    this.orderLine['quantity-ordered'];
-            }
         };
 
         return OrderLine;
@@ -792,7 +780,6 @@ var azureProvidersModule = angular
             var resource = AzureAPI['order-line'].save(data);
             resource.$promise.then(function(line) {
                 _this.orderLine = line;
-                _this._calculatePrice();
                 _this.cart._calculateTotals();
                 return line;
             });

--- a/azure-providers.js
+++ b/azure-providers.js
@@ -542,8 +542,8 @@ var azureProvidersModule = angular
                 });
                 return $q.all(promises).then(function() {
                     _this.packaging.sort(function(a, b) {
-                        return a.packaged.price.dollars -
-                            b.packaged.price.dollars;
+                        return a.packaged.price.retail.dollars -
+                            b.packaged.price.retail.dollars;
                     });
                     _this.selectPackaging(code);
                 }).then(function() {


### PR DESCRIPTION
Catch up with azurestandard/api-spec@01861207 (public.json: Add
person.price-level and a multi-level price object, 2015-09-16,
azurestandard/api-spec#29) and azurestandard/api-spec@9658ee1
(public.json: Make orderLine.price a total dollar value,
azurestandard/api-spec#36).  Details in the commit messages.

This is part of the client-side adjustment for
azurestandard/beehive#1244.