### PR TITLE
Adjust to purchase-order -> purchase API rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Currently supported models:
 * person
 * pickup
 * product
-* purchase-order
+* purchase
 * region
 * route
 * route-stop

--- a/azure-providers.js
+++ b/azure-providers.js
@@ -37,7 +37,7 @@ var azureProvidersModule = angular
             'person',
             'pickup',
             'product',
-            'purchase-order',
+            'purchase',
             'region',
             'route',
             'route-stop',


### PR DESCRIPTION
The previous /purchase-orders API wasn't spec'ed, and
azurestandard/api-spec@21ec51e (public.json: Add 'GET /purchases' and
'GET /purchase/{id}', 2015-10-31, azurestandard/api-spec#49) is using
the shorter form.
