### PR TITLE
AzureAPI: Pass $http.post data through directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,20 +156,21 @@ There's also:
 
 * `AzureAPI.session.get()` to get information about your existing
   session (e.g. whether it's anonymous or not).
-* `AzureAPI.login(username, password)` to start an authenticated
-  session.  It returns an [HttpPromise][] for a session object.
+* `AzureAPI.login({username: ..., password: ...})` to start an
+  authenticated session.  It returns an [HttpPromise][] for a session
+  object.
 * `AzureAPI.logout()` to leave an authenticated session.  It returns
   an [HttpPromise][] for an unauthenticated session object.
-* `AzureAPI.register(baseURL, person, address, telephone, drop)` to
-  register a new user. It returns an [HttpPromise][] for an object
-  containing the resend token.
-* `AzureAPI.activate(token)` to activate a registration using the
-  confirmation token (which was emailed to the registrant, and is
+* `AzureAPI.register({'base-url': ..., person: ..., address: ...,
+  telephone: ..., drop: ...})` to register a new user. It returns an
+  [HttpPromise][] for an object containing the resend token.
+* `AzureAPI.activate({token: ...})` to activate a registration using
+  the confirmation token (which was emailed to the registrant, and is
   different from the resend token returned by `AzureAPI.register`). It
   returns an [HttpPromise][] for a the activated person object.
-* `AzureAPI.resendConfirmationEmail(token, baseURL)` to resend the
-  confirmation email to the user with the given resend token. It
-  returns an [HttpPromise][] for a 204 response.
+* `AzureAPI.resendConfirmationEmail({token: ..., 'base-url': ...})` to
+  resend the confirmation email to the user with the given resend
+  token. It returns an [HttpPromise][] for a 204 response.
 
 AzureCategory
 =============

--- a/azure-providers.js
+++ b/azure-providers.js
@@ -80,6 +80,13 @@ var azureProvidersModule = angular
             if (algoliaAppId && algoliaApiKey) {
                 algoliaClient = algolia.Client(algoliaAppId, algoliaApiKey);
             }
+            var payloadHeaders = {};
+            for (var header in _headers) {
+                payloadHeaders[header] = _headers[header];
+            }
+            for (var header in _payloadHeaders) {
+                payloadHeaders[header] = _payloadHeaders[header];
+            }
             var resources = {
                 session: $resource(
                     url + '/session',
@@ -100,7 +107,7 @@ var azureProvidersModule = angular
                             'password': password,
                         },
                         {
-                            headers: _headers,
+                            headers: payloadHeaders,
                             withCredentials: true
                         }
                     );
@@ -110,7 +117,7 @@ var azureProvidersModule = angular
                         url + '/logout',
                         {},
                         {
-                            headers: _headers,
+                            headers: payloadHeaders,
                             withCredentials: true
                         }
                     );
@@ -126,7 +133,7 @@ var azureProvidersModule = angular
                             drop: drop,
                         },
                         {
-                            headers: _headers,
+                            headers: payloadHeaders,
                         }
                     );
                 },
@@ -137,7 +144,7 @@ var azureProvidersModule = angular
                             token: token,
                         },
                         {
-                            headers: _headers,
+                            headers: payloadHeaders,
                         }
                     );
                 },
@@ -149,18 +156,11 @@ var azureProvidersModule = angular
                             'base-url': baseURL,
                         },
                         {
-                            headers: _headers,
+                            headers: payloadHeaders,
                         }
                     );
                 }
             };
-            var payloadHeaders = {};
-            for (var header in _headers) {
-                payloadHeaders[header] = _headers[header];
-            }
-            for (var header in _payloadHeaders) {
-                payloadHeaders[header] = _payloadHeaders[header];
-            }
             _models.forEach(function(model) {
                 var plural = _plurals[model] || model + 's';
                 var identifier = AzureModelIdentifiers[model] || 'id';

--- a/azure-providers.js
+++ b/azure-providers.js
@@ -40,6 +40,28 @@ var azureProvidersModule = angular
             'category': 'categories',
             'person': 'people',
         };
+
+        // non-$resource endpoints that will use $http.post(...)
+        var _posts = {
+            login: {
+                url: '/login',
+                withCredentials: true,
+            },
+            logout: {
+                url: '/logout',
+                withCredentials: true,
+            },
+            register: {
+                url: '/registration/register',
+            },
+            activate: {
+                url: '/registration/confirm',
+            },
+            resendConfirmationEmail: {
+                url: '/registration/resend',
+            },
+        };
+
         var _headers = {
             'Accept': 'application/json',
         };
@@ -99,68 +121,33 @@ var azureProvidersModule = angular
                         }
                     }
                 ),
-                login: function(username, password) {
-                    return $http.post(
-                        url + '/login',
-                        {
-                            'username': username,
-                            'password': password,
-                        },
-                        {
-                            headers: payloadHeaders,
-                            withCredentials: true
-                        }
-                    );
-                },
-                logout: function() {
-                    return $http.post(
-                        url + '/logout',
-                        {},
-                        {
-                            headers: payloadHeaders,
-                            withCredentials: true
-                        }
-                    );
-                },
-                register: function(baseURL, person, address, telephone, drop) {
-                    return $http.post(
-                        url + '/registration/register',
-                        {
-                            'base-url': baseURL,
-                            person: person,
-                            address: address,
-                            telephone: telephone,
-                            drop: drop,
-                        },
-                        {
-                            headers: payloadHeaders,
-                        }
-                    );
-                },
-                activate: function(token) {
-                    return $http.post(
-                        url + '/registration/confirm',
-                        {
-                            token: token,
-                        },
-                        {
-                            headers: payloadHeaders,
-                        }
-                    );
-                },
-                resendConfirmationEmail: function(token, baseURL) {
-                    return $http.post(
-                        url + '/registration/resend',
-                        {
-                            token: token,
-                            'base-url': baseURL,
-                        },
-                        {
-                            headers: payloadHeaders,
-                        }
-                    );
-                }
             };
+
+            var payloadHeaders = {};
+            for (var header in _headers) {
+                payloadHeaders[header] = _headers[header];
+            }
+            for (var header in _payloadHeaders) {
+                payloadHeaders[header] = _payloadHeaders[header];
+            }
+            for (var name in _posts) {
+                var postConfig = _posts[name];
+                var config = {
+                    headers: payloadHeaders,
+                };
+                if (postConfig.withCredentials) {
+                    config.withCredentials = true;
+                }
+                resources[name] = (function(postConfig, config) {
+                    return function(data) {
+                        return $http.post(
+                            url + postConfig.url,
+                            data,
+                            config
+                        );
+                    };
+                })(postConfig, config);
+            }
             _models.forEach(function(model) {
                 var plural = _plurals[model] || model + 's';
                 var identifier = AzureModelIdentifiers[model] || 'id';

--- a/example.html
+++ b/example.html
@@ -316,10 +316,10 @@
 						$scope.warning = null;
 						$scope.login = function() {
 							$scope.warning = null;
-							AzureAPI.login(
-								$scope.credentials.username,
-								$scope.credentials.password
-							).success(function(session) {
+							AzureAPI.login({
+								username: $scope.credentials.username,
+								password: $scope.credentials.password
+							}).success(function(session) {
 								var person = AzureAPI.person.get({id: session.person});
 								person.$promise.then(function(person) {
 									$rootScope.setupPerson(person);


### PR DESCRIPTION
Instead of using function arguments arguments for the first level of keys.  This way you don't have to remember/lookup the argument order.

This is a backwards-incompatible change to those APIs, but it allows for more direct binding between the API spec and the caller.  On the one hand, that means we don't need to update this library if the API shuffles its expected fields.  On the other hand, that means we can't buffer callers when the API shuffles its expected fields (but shuffling will probably include semantic changes, and callers will have to update to handle those anyway).

Spun off from azurestandard/website#83, pulling in azurestandard/azure-angular-providers@99d1c2c from tk/refactor which was based on a change in azurestandard/azure-angular-providers@eb018dc in jh/refactor, part of the abandoned #7.  I've put this on top of the commit from #13, since we might as well fix that error while we're messing with the $http.post handling.