### PR TITLE
example.html: Import algoliasearch.angular.min.js from jsDelivr

### DIFF
--- a/example.html
+++ b/example.html
@@ -227,6 +227,7 @@
 
 		<script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.3.0/angular.min.js"></script>
 		<script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.3.0/angular-resource.min.js"></script>
+		<script src="https://cdn.jsdelivr.net/algoliasearch/3.9.2/algoliasearch.angular.min.js"></script>
 		<script src="azure-providers.js"></script>
 		<script type="text/javascript">
 			angular.module('AzureApp', ['azureProviders'])


### PR DESCRIPTION
Avoid the following error (made readable by using non-.min versions of
the Angular scripts):

  14:50:22.936 Error: [$injector:modulerr] Failed to instantiate module AzureApp due to:
  [$injector:modulerr] Failed to instantiate module azureProviders due to:
  [$injector:modulerr] Failed to instantiate module algoliasearch due to:
  [$injector:nomod] Module 'algoliasearch' is not available! You
    either misspelled the module name or forgot to load it. If
    registering a module ensure that you specify the dependencies as
    the second argument.
  http://errors.angularjs.org/1.3.0/$injector/nomod?p0=algoliasearch
  minErr/<@http://ajax.googleapis.com/ajax/libs/angularjs/1.3.0/angular.js:80:12
  module/<@http://ajax.googleapis.com/ajax/libs/angularjs/1.3.0/angular.js:1797:1
  ensure@http://ajax.googleapis.com/ajax/libs/angularjs/1.3.0/angular.js:1721:38
  module@http://ajax.googleapis.com/ajax/libs/angularjs/1.3.0/angular.js:1795:1
  loadModules/<@http://ajax.googleapis.com/ajax/libs/angularjs/1.3.0/angular.js:4064:22
  forEach@http://ajax.googleapis.com/ajax/libs/angularjs/1.3.0/angular.js:335:11
  loadModules@http://ajax.g1 angular.js:80:11

jsDelivr is Algolia's recommended CDN [1], and 3.9.2 is their latest
release (2015-11-05 [2]).  The angular-specific URL comes from [3].
This should have landed in bf845121 (AzureAPI: Add Algolia client
indexes to models, 2015-09-24, #12).

[1]: https://github.com/algolia/algoliasearch-client-js/tree/3.9.2#script-tag-using-jsdelivr
[2]: https://github.com/algolia/algoliasearch-client-js/tags
[3]: http://www.jsdelivr.com/?query=algoliasearch