### PR TITLE
replace packaged-product algolia index with brand index

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ mapping the model name to your Algolia index name:
 
 By default, indexes are provided for the following models:
 
+* brand
 * category
 * drop
-* packaged-product
 * product
 
 Where the default index name is just the plural model name

--- a/azure-providers.js
+++ b/azure-providers.js
@@ -85,9 +85,9 @@ var azureProvidersModule = angular
         };
 
         var algoliaIndexNames = {
+            'brand': 'brands',
             'category': 'categories',
             'drop': 'drops',
-            'packaged-product': 'packaged-products',
             'product': 'products',
         };
 


### PR DESCRIPTION
We are not using a packaged-product index in Algolia, but we do have a brand index, so this simply replaces the packaged-product index declaration with a declaration for the brand index.