### PR TITLE
README: Add an algolia-search URL reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,6 +394,7 @@ Examples
 
 See the [demo page][demo] for a brief example.
 
+[algolia-search]: https://www.algolia.com/doc/javascript#search
 [api]: https://github.com/azurestandard/api-spec
 [AngularJS]: https://angularjs.org/
 [resource]: https://docs.angularjs.org/api/ngResource/service/$resource


### PR DESCRIPTION
This was in a01ca4c2 (AzureAPI: Add AzureAPIProvider.algoliaIndices to
configure index names, 2015-09-14) but was dropped accidentally in the
reroll process that resulted in in the merged bf845121 (AzureAPI: Add
Algolia client indexes to models, 2015-09-24, #12).