### PR TITLE
force algolia to use https

### DIFF
--- a/azure-providers.js
+++ b/azure-providers.js
@@ -103,7 +103,7 @@ var azureProvidersModule = angular
         this.$get = ['$http', '$resource', 'algolia', 'AzureModelIdentifiers', function AzureAPIFactory($http, $resource, algolia, AzureModelIdentifiers) {
             var algoliaClient;
             if (algoliaAppId && algoliaApiKey) {
-                algoliaClient = algolia.Client(algoliaAppId, algoliaApiKey);
+                algoliaClient = algolia.Client(algoliaAppId, algoliaApiKey, {protocol: 'https:'});
             }
             var payloadHeaders = {};
             for (var header in _headers) {


### PR DESCRIPTION
This is required to use the .browseAll() method that is being used for loading all drops, plus using https is just a good idea.