### PR TITLE
expose algolia client object

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,10 +131,12 @@ The drop model also supports the following action:
 Algolia search
 --------------
 
-If you've [configured the Algolia client](#configuration), models
-listed in `algoliaIndexNames` will have an initialized index attached
-as the `.algolia` property. For example, with the earlier
-[configuration examples](#configuration), you could use:
+If you've [configured the Algolia client](#configuration), the [Algolia
+client](https://github.com/algolia/algoliasearch-client-js) will be available 
+as `AzureAPI.algolia()`. In addition, models listed in `algoliaIndexNames`
+will have an initialized index attached as the `.algolia` property. For
+example, with the earlier [configuration examples](#configuration), you could
+use:
 
     AzureAPI.category.algolia.search(…);
     AzureAPI.drop.algolia.search(…);

--- a/azure-providers.js
+++ b/azure-providers.js
@@ -126,6 +126,7 @@ var azureProvidersModule = angular
                         }
                     }
                 ),
+                algolia: algoliaClient,
             };
 
             var payloadHeaders = {};


### PR DESCRIPTION
Access to the Algolia client object is required to perform
multiple-index searches.