### PR TITLE
azure-providers.js: Expose coordinator information in AzureOrder

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,7 @@ the additional property:
 For orders scheduled for delivery on a drop and trip,
 the `Order` instance will have the additional properties:
 
+* `contact`, the primary contact for this drop.
 * `drop`, the drop to which the customer wants the order delivered.
 * `stop`, the stop on which the customer's order will be delivered.
 * `trip`, the trip on which the customer's order will be delivered.

--- a/azure-providers.js
+++ b/azure-providers.js
@@ -653,8 +653,14 @@ var azureProvidersModule = angular
         };
 
         Order.prototype._drop = function() {
+            var _this = this;
             this.drop = AzureAPI.drop.get({
                 id: this.order.drop,
+            });
+            this.drop.$promise.then(function (drop) {
+                if (drop.coordinators && drop.coordinators.length > 0) {
+                    _this._contact();
+                }
             });
         };
 
@@ -673,6 +679,12 @@ var azureProvidersModule = angular
         Order.prototype._payment = function() {
             this.payment = AzureAPI['payment-method'].get({
                 id: this.order['checkout-payment'].method
+            });
+        };
+
+        Order.prototype._contact = function () {
+            this.contact = AzureAPI.person.get({
+                id: this.drop.coordinators[0]
             });
         };
 


### PR DESCRIPTION
The frontend requires more information on a drop's coordinator then just an ID.

This commit returns a person $resource for the drop. Note, if there are more than one coordinator, only the first coordinator's information is returned.