### PR TITLE
azure-providers.js: Default active cart should have 'cart' status

### DIFF
--- a/azure-providers.js
+++ b/azure-providers.js
@@ -892,7 +892,9 @@ var azureProvidersModule = angular
                         _this.carts.sort(function(a, b) {
                             return getDate(a) - getDate(b);
                         });
-                        _this.cart = _this.carts[0];
+                        if (cart.order.status === 'cart') {
+                            _this.cart = cart;
+                        }
                         return cart.trip;
                     };
                 };


### PR DESCRIPTION
Resolves azurestandard/website#174

Customers must explicty hit the continue shopping button to make a 'placed' cart active.