### PR TITLE
AzureOrder: Catch up with .checkout-payment.payment-method

### DIFF
--- a/azure-providers.js
+++ b/azure-providers.js
@@ -679,7 +679,7 @@ var azureProvidersModule = angular
 
         Order.prototype._payment = function() {
             this.payment = AzureAPI['payment-method'].get({
-                id: this.order['checkout-payment'].method
+                id: this.order['checkout-payment']['payment-method']
             });
         };
 


### PR DESCRIPTION
The API has specified .payment-method since azurestandard/api-spec@7e8b6814 (public.json: Add order.checkout-payment, 2015-10-02, azurestandard/api-spec#39).  The implemented backend had been using .method since azurestandard/beehive@34e7a19c (apps/api/views/order.py: Add order.payment fields, 2015-04-23), but is catching up with the API spec in azurestandard/beehive@d5c3cdc8 (apps/api/views/order.py: Fix .method -> .payment-method, 2016-03-21, azurestandard/beehive#1636).

Don't merge this until azurestandard/beehive#1636 lands ;).