### PR TITLE
example.html: Migrate from deprecated .success and .error

### DIFF
--- a/example.html
+++ b/example.html
@@ -321,7 +321,8 @@
 							AzureAPI.login({
 								username: $scope.credentials.username,
 								password: $scope.credentials.password
-							}).success(function(session) {
+							}).then(function(response) {
+								var session = response.data;
 								var person = AzureAPI.person.get({id: session.person});
 								person.$promise.then(function(person) {
 									$rootScope.setupPerson(person);
@@ -330,8 +331,8 @@
 									$scope.warning = 'unable to get person ' + session.person;
 									$timeout(function() {$scope.warning = null;}, 5000);
 								})
-							}).error(function(data, status) {
-								$scope.warning = 'unable to authenticate';
+							}).catch(function(response) {
+								$scope.warning = 'unable to authenticate ' + response.status;
 								$timeout(function() {$scope.warning = null;}, 5000);
 							});
 						};


### PR DESCRIPTION
Angular [v1.4.4][1] [deprecated][2] [them][3] in favor of the generic
`$promise.then` (and presumably `.catch`).

[1]: https://github.com/angular/angular.js/blob/v1.4.4/CHANGELOG.md#features
[2]: https://docs.angularjs.org/api/ng/service/$http#deprecation-notice
[3]: https://github.com/angular/angular.js/pull/12112