### PR TITLE
Implementation of missing save() function of AzureLocalCarts OrderLine.

### DIFF
--- a/azure-providers.js
+++ b/azure-providers.js
@@ -1069,6 +1069,18 @@ var azureProvidersModule = angular
         OrderLine.prototype = Object.create(AzureOrderLine.prototype);
         OrderLine.prototype.constructor = OrderLine;
 
+        OrderLine.prototype._calculate = function () {
+            var quantityOrdered = this.orderLine['quantity-ordered'];
+            this.orderLine.price = this.product.packaged.packaged.price.retail.dollars * quantityOrdered;
+            this.orderLine.volume = this.product.packaged.packaged.volume * quantityOrdered;
+            this.orderLine.weight = this.product.packaged.packaged.weight.average * quantityOrdered;
+        };
+
+        OrderLine.prototype.save = function() {
+            this._calculate();
+            this.cart._calculateTotals();
+        };
+
         OrderLine.prototype.delete = function() {
             var index = this.cart.orderLines.indexOf(this);
             $localStorage.orderLines.splice(index, 1);
@@ -1078,15 +1090,13 @@ var azureProvidersModule = angular
 
         OrderLine.prototype.increment = function() {
             this.orderLine['quantity-ordered'] += 1;
-            this.orderLine.price = this.orderLine['quantity-ordered'] * this.product.packaged.packaged.price.retail.dollars;
-            this.cart._calculateTotals();
+            this.save();
         };
 
         OrderLine.prototype.decrement = function() {
             if (this.orderLine['quantity-ordered'] > 1) {
                 this.orderLine['quantity-ordered'] -= 1;
-                this.orderLine.price = this.orderLine['quantity-ordered'] * this.product.packaged.packaged.price.retail.dollars;
-                this.cart._calculateTotals();
+                this.save();
             }
         };
 
@@ -1140,23 +1150,17 @@ var azureProvidersModule = angular
 
         Cart.prototype.addLine = function(productCode, quantityOrdered) {
             var _this = this;
-            var product = AzureAPI['packaged-product'].get({
-                code: productCode
-            });
-            product.$promise.then(function(product) {
-                var line = {};
-                line['packaged-product'] = product.code;
-                line['quantity-ordered'] = quantityOrdered;
-                line.price = product.price.retail.dollars * quantityOrdered;
-                line.volume = product.volume * quantityOrdered;
-                line.weight = product.weight.average * quantityOrdered;
-                line = _this._newOrderLine(line);
+            var line = {};
+            line['packaged-product'] = productCode;
+            line['quantity-ordered'] = quantityOrdered;
+            line = this._newOrderLine(line);
+            $localStorage.orderLines.push(line.orderLine);
+            return line.product.$promise.then(function() {
+                line._calculate();
                 _this.orderLines.push(line);
-                $localStorage.orderLines.push(line.orderLine);
                 _this._calculateTotals();
-
+                return line.product;
             });
-            return product.$promise;
         };
 
         var Carts = function(personId) {


### PR DESCRIPTION
Resolves #43.

When the user changes the quantity of an order line on the cart page, [the `save()` method of the `orderLine` object is called](https://github.com/azurestandard/website/blob/67c1965190f2e8a62661a427d60d0b8fb97f539c/app/views/partials/cart_product_rows.html#L26). If it's a local cart, nothing happens because the method is not implemented on the `AzureLocalCarts` version of `OrderLine`. This implementation of the missing save method calculates the orderLine based on the quantity entered and recalculates the cart totals.