### PR TITLE
azure-providers.js: Remove leftover AzureOrder.shipping

### DIFF
--- a/azure-providers.js
+++ b/azure-providers.js
@@ -741,7 +741,6 @@ var azureProvidersModule = angular
             this.weight = 0;
             this.volume = 0;
             this.products = 0;
-            this.shipping = 0;
             totalQuantityOrdered = {};
             totalQuantityShipped = {};
             this.orderLines.forEach(function(line) {


### PR DESCRIPTION
The bulk of the .shipping property was removed in 383b6ba
(azure-providers.js: Remove order.shipping, 2016-03-25, #40), and this
instance just slipped through.  Clients should be looking in
order.fees for shipping (and other) fees.