### PR TITLE
Support azurestandard/api-spec#158.

### DIFF
--- a/azure-providers.js
+++ b/azure-providers.js
@@ -67,6 +67,7 @@ var azureProvidersModule = angular
             },
             activate: {
                 url: '/registration/confirm',
+                withCredentials: true,
             },
             resendConfirmationEmail: {
                 url: '/registration/resend',


### PR DESCRIPTION
Support azurestandard/api-spec#158.

This change causes set-cookie to work in the response to /registration/confirm. Without it, the cookie is ignored.

Blocking azurestandard/website#653.