### PR TITLE
Support azurestandard/api-spec#182

### DIFF
--- a/azure-providers.js
+++ b/azure-providers.js
@@ -65,9 +65,6 @@ var azureProvidersModule = angular
             },
             register: {
                 url: '/registration/register',
-            },
-            activate: {
-                url: '/registration/confirm',
                 withCredentials: true,
             },
             resendConfirmationEmail: {


### PR DESCRIPTION
This change causes set-cookie to work in the response to
/registration/register and removes /registration/confirm.