### PR TITLE
AzureProduct: Sort variable-weight packaging by average retail price

### DIFF
--- a/azure-providers.js
+++ b/azure-providers.js
@@ -594,6 +594,14 @@ var azureProvidersModule = angular
             return this.categories()[0];  // TODO: shortest chain through Bulk?
         };
 
+        PackagedProduct.prototype.averagePrice = function(level) {
+            var price = this.packaged.price[level].dollars;
+            if (this.packaged.price[level]['per-pound']) {
+                price *= this.packaged.weight.average;
+            }
+            return price;
+        }
+
         var Product = function(promise, code) {
             var _this = this;
             this.$promise = promise.then(function(product) {
@@ -607,8 +615,7 @@ var azureProvidersModule = angular
                 });
                 return $q.all(promises).then(function() {
                     _this.packaging.sort(function(a, b) {
-                        return a.packaged.price.retail.dollars -
-                            b.packaged.price.retail.dollars;
+                        return a.averagePrice('retail') - b.averagePrice('retail');
                     });
                     _this.selectPackaging(code);
                 }).then(function() {


### PR DESCRIPTION
Previously we were just sorting by price.retail.dollars, regardless of variable-weight-ness.  For variable-weight products, that dollar value is per-pound, which was sorting bulkier, more efficient items earlier in the packaging list.  Our goal is to sort smaller, more expensive (per-pound) items earlier in the list because they have the prettiest pictures (bulk item pictures are usually just cardboard boxes).