### PR TITLE
AzureAPI: Rename resendConfirmationEmail to resendRegistrationEmail

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,8 +186,8 @@ There's also:
   the resend token and a session object. If a new user was created,
   the session object will have a person property and the response will
   authenticate the user.
-* `AzureAPI.resendConfirmationEmail({token: ..., 'base-url': ...})` to
-  resend the confirmation email to the user with the given resend
+* `AzureAPI.resendRegistrationEmail({token: ..., 'base-url': ...})` to
+  resend the registration email to the user with the given resend
   token. It returns an [HttpPromise][] for a 204 response.
 * `AzureAPI.resetPassword({email: ..., 'base-url': ...})` to
   send a password-reset confirmation email to the user.

--- a/azure-providers.js
+++ b/azure-providers.js
@@ -67,7 +67,7 @@ var azureProvidersModule = angular
                 url: '/registration/register',
                 withCredentials: true,
             },
-            resendConfirmationEmail: {
+            resendRegistrationEmail: {
                 url: '/registration/resend',
             },
             resetPassword: {


### PR DESCRIPTION
Since azurestandard/api-spec#182), the registration email is no longer about confirming the registration.  Make the method name more generic (which also brings it closer to the endpoint's URL).