### PR TITLE
azure-providers: Drop AzureAPI.email.confirm and confirmResend

### DIFF
--- a/azure-providers.js
+++ b/azure-providers.js
@@ -226,20 +226,6 @@
                         },
                     };
                 }
-                if (model === 'email') {
-                    actions.confirm = {
-                        method: 'POST',
-                        url: _apiUrl + '/' + plural + '/confirm',
-                        withCredentials: true,
-                        headers: _headers,
-                    };
-                    actions.confirmResend = {
-                        method: 'POST',
-                        url: _apiUrl + '/email/:' + identifier + '/resend',
-                        withCredentials: true,
-                        headers: _headers,
-                    };
-                }
                 if (model === 'order') {
                     actions.parcelCarrierEstimates = {
                         method: 'GET',


### PR DESCRIPTION
These were added in #62, although [we forgot to document them][1].  We've dropped those endpoints from the API in azurestandard/api-spec#195.

[1]: https://github.com/azurestandard/azure-angular-providers/pull/62#pullrequestreview-6923450