### PR TITLE
added necessary post requests for the NMI three step redirect

### DIFF
--- a/azure-providers.js
+++ b/azure-providers.js
@@ -89,6 +89,13 @@
             },
             resetPasswordConfirm: {
                 url: '/password/confirm'
+            },
+            getNmiStepOneFormSubmitUrl: {
+                url: '/nmi-step1-form-url',
+                withCredentials: true
+            },
+            handleNmiStepThreeRedirect: {
+                url: '/nmi-step3-form-url'
             }
         };
 

--- a/azure-providers.js
+++ b/azure-providers.js
@@ -95,7 +95,7 @@
                 withCredentials: true
             },
             handleNmiStepThreeRedirect: {
-                url: '/nmi-step3-form-url'
+                url: '/nmi-process-step3'
             }
         };
 

--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,7 @@
         "service",
         "provider"
     ],
-    "version": "2.6.0",
+    "version": "2.7.0",
     "license": "MIT",
     "main": "./azure-providers.js",
     "homepage": "https://github.com/azurestandard/azure-angular-providers",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-angular-providers",
-    "version": "2.6.0",
+    "version": "2.7.0",
     "main": "azure-providers",
     "description": "Azure Standard API provider for AngularJS",
     "homepage": "https://github.com/azurestandard/azure-angular-providers",


### PR DESCRIPTION
added necessary post requests for the NMI three step redirect

The first is to separate the customer vault creation from the paymentmethod.py view.

The second is to accept the POST request sent back by NMI during step 3 of transactions.